### PR TITLE
patch-2

### DIFF
--- a/azure_databricks_api/__workspace.py
+++ b/azure_databricks_api/__workspace.py
@@ -120,7 +120,7 @@ class WorkspaceAPI(RESTBase):
 
         if resp.status_code == 200:
             with open(file_path, 'wb+') as fo:
-                fo.write(resp.get('content'))
+                fo.write(resp.content)
 
             return file_path
 


### PR DESCRIPTION
updated workspace export functionality.  It was erroring out with "response object has no attribute 'get'".  Replaced this with resp.content as this works correctly.