### PR TITLE
Fix requests.get() parameter passing

### DIFF
--- a/azure_databricks_api/__base.py
+++ b/azure_databricks_api/__base.py
@@ -35,7 +35,7 @@ class RESTBase(object):
             api_endpoint = api_endpoint[1:]
 
         uri = self._uri + api_endpoint
-        return requests.get(url=uri, headers=self._headers, params=data)
+        return requests.get(url=uri, headers=self._headers, json=data)
 
     def __post(self, api_endpoint, data):
         """


### PR DESCRIPTION
Databricks API expects JSON objects when making GET/POST requests. In the current implementation, if I, for example, try
```python
AzureDatabricksRESTClient(region=<azure_region>, token=<token>).workspace.export(...)
```
`'direct_download': True` parameter is passed via `params` argument to `requests.get()` and is represented as `True` vs `true`, therefore it's not interpreted properly and I get a base64-encoded version of a file instead of the exported file itself.

Since Python Requests handles both `data` and `json` arguments in addition to `params`, switching to `json` (Python objects are JSON-serialized when you use it) fixes the issue.