### PR TITLE
Fix dictionary type check in create

### DIFF
--- a/azure_databricks_api/__clusters.py
+++ b/azure_databricks_api/__clusters.py
@@ -82,7 +82,7 @@ class ClusterAPI(RESTBase):
             kwargs['autotermination_minutes'] = autotermination_minutes
 
         # Specify the size of the cluster
-        if type(num_workers) == 'dict':
+        if type(num_workers) is dict:
             cluster_config['autoscale'] = num_workers
         else:
             cluster_config['num_workers'] = int(num_workers)

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -77,7 +77,7 @@ def test_create_cluster(cluster_name, spark_versions, smallest_node):
                                      spark_version=list(spark_versions.keys())[0], node_type_id=smallest_node)
 
 
-def test_create_cluster_with_autoscale(cluster_name, spark_versions, smallest_node):
+def test_create_cluster_with_autoscale(cluster_name, spark_versions, smallest_node, autoscale_num_workers):
     cluster = client.clusters.create(cluster_name=cluster_name, num_workers=autoscale_num_workers,
                                      spark_version=list(spark_versions.keys())[0], node_type_id=smallest_node)
 

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -51,6 +51,14 @@ def smallest_node(node_types):
     return sorted_nodes[0]['node_type_id']
 
 
+@pytest.fixture(scope="module")
+def autoscale_num_workers():
+    return {
+        "min_workers": 0,
+        "max_workers": 0
+    }
+
+
 def test_create_cluster_invalid_spark_version_raises(cluster_name, smallest_node):
     with pytest.raises(ValueError):
         _ = client.clusters.create(cluster_name=cluster_name, num_workers=0,
@@ -66,6 +74,11 @@ def test_create_cluster_invalid_node_raises_error(cluster_name, spark_versions):
 
 def test_create_cluster(cluster_name, spark_versions, smallest_node):
     cluster = client.clusters.create(cluster_name=cluster_name, num_workers=0,
+                                     spark_version=list(spark_versions.keys())[0], node_type_id=smallest_node)
+
+
+def test_create_cluster_with_autoscale(cluster_name, spark_versions, smallest_node):
+    cluster = client.clusters.create(cluster_name=cluster_name, num_workers=autoscale_num_workers,
                                      spark_version=list(spark_versions.keys())[0], node_type_id=smallest_node)
 
 


### PR DESCRIPTION
Currently cluster creation fails when setting num_workers to the autoscale configuration:
```
 File "xxx\venv\lib\site-packages\azure_databricks_api\__clusters.py", line 88, in create
    cluster_config['num_workers'] = int(num_workers)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'dict'
```